### PR TITLE
fix: Restricted passkey redirects to the page origin

### DIFF
--- a/custom_components/webauthn_mfa/www/authenticate.html
+++ b/custom_components/webauthn_mfa/www/authenticate.html
@@ -108,10 +108,25 @@
         : T.btnAuth;
     }
 
+    function getSafeReturnUrl(fallback = "/") {
+      const urlValue = RETURN_URL || new URLSearchParams(window.location.search).get("return_url") || "";
+      if (!urlValue) {
+        return fallback;
+      }
+      try {
+        const parsed = new URL(urlValue, window.location.origin);
+        if (parsed.origin !== window.location.origin) {
+          return fallback;
+        }
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      } catch (_) {
+        return fallback;
+      }
+    }
+
     function goBack() {
       sessionStorage.setItem("webauthn_bypass", "1");
-      const params = new URLSearchParams(window.location.search);
-      window.location.href = params.get("return_url") || "/";
+      window.location.href = getSafeReturnUrl("/");
     }
 
     function bufferToBase64url(buffer) {
@@ -210,7 +225,7 @@
           }));
 
           setTimeout(() => {
-            window.location.href = RETURN_URL || "/auth/authorize";
+            window.location.href = getSafeReturnUrl("/auth/authorize");
           }, 300);
         } else {
           setStatus(`${T.failed}: ${verifyData.error || T.unknown}`, "error");


### PR DESCRIPTION
The authentication page took `return_url` straight from the query string and assigned it to `window.location.href`, so a crafted link could send a user to another origin after authenticating, and a `javascript:` or `data:` value reached a navigation sink.

`getSafeReturnUrl()` now resolves the value with `new URL(value, window.location.origin)`, rejects anything whose origin does not match the page, and returns only the path, query and fragment. Protocol-relative values like `//example.com` resolve to a foreign origin and are rejected, and `javascript:`/`data:` values resolve to a null origin and are rejected too. Both redirect sinks go through it, each keeping its own fallback.

Closes two code scanning alerts. Independent of the other two split PRs, touches only this one file.